### PR TITLE
Keep subfolder structure of glob match intact

### DIFF
--- a/src/io/file.ts
+++ b/src/io/file.ts
@@ -1,5 +1,6 @@
 export interface IFile {
   location: string;
+  base: string;
   content?: string;
   map: boolean | string;
 }

--- a/src/io/writeFiles.ts
+++ b/src/io/writeFiles.ts
@@ -15,12 +15,15 @@ export function writeFiles(dest: string) {
       files.map((file: IFile) => {
         const name = path.basename(file.location);
 
-        return mkdirp(dest).then(() => {
-          const outPath = path.join(dest, name);
+        // Keep subfolder structure if we find any
+        const fileDest = path.resolve(path.join(dest, file.base));
+
+        return mkdirp(fileDest).then(() => {
+          const outPath = path.join(fileDest, name);
           fs.writeFileSync(outPath, file.content);
 
           if (file.map !== null) {
-            fs.writeFileSync(path.join(dest, name), file.content);
+            fs.writeFileSync(path.join(fileDest, name), file.content);
           }
 
           file.location = outPath;

--- a/src/tasks/build.ts
+++ b/src/tasks/build.ts
@@ -12,9 +12,10 @@ process.env.NODE_ENV = "production";
 
 // Sass
 export function buildSass(config: IKikiSassConfig) {
-  const globPath = path.resolve(config.src) + "/**/*.scss";
+  const base = path.resolve(config.src);
+  const globPath = base + "/**/*.scss";
 
-  return task(globPath, "sass")
+  return task(globPath, base, "sass")
     .then(sass(config))
     .then(writeFiles(config.dest))
     .catch((err: Error) => {

--- a/src/tasks/task.ts
+++ b/src/tasks/task.ts
@@ -3,7 +3,7 @@ import { filesFromMatch } from "../utils";
 import * as glob from "glob-promise";
 
 const globOptions = { follow: true, ignore: "**/_*" };
-export default function task(globPath: string, taskName: string) {
+export default function task(globPath: string, basePath: string, taskName: string) {
   emitter.start(taskName, globPath);
 
   return glob(globPath, globOptions).then((matches: string[]) => {
@@ -12,6 +12,6 @@ export default function task(globPath: string, taskName: string) {
       return [];
     }
 
-    return filesFromMatch(matches);
+    return filesFromMatch(matches, basePath);
   });
 };

--- a/src/tasks/watch.ts
+++ b/src/tasks/watch.ts
@@ -28,7 +28,7 @@ export function watch(config: IKikiConfig) {
     const start = new Date().getTime();
 
     if (/.+\.scss$/.test(path)) {
-      const files = filesFromMatch([path]);
+      const files = filesFromMatch([path], config.sass.src);
 
       return sass(config.sass)(files)
         .then(writeFiles(config.sass.dest))

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,9 +9,13 @@ export function replaceExtension(file: string, ext: string) {
   return path.join(path.dirname(file), nFile);
 }
 
-export function filesFromMatch(matches: string[]): IFile[] {
+export function filesFromMatch(matches: string[], base: string): IFile[] {
   return matches.map(match => {
+    const name = path.basename(match);
+    let relative = path.relative(base, match.replace(name, ""));
+
     return {
+      base: relative,
       location: match,
       map: null,
     };

--- a/test/io/writeFiles.spec.ts
+++ b/test/io/writeFiles.spec.ts
@@ -1,18 +1,14 @@
 /* global describe:true */
 import { IFile } from "../../src/io/file";
 import { writeFiles as write } from "../../src/io/writeFiles";
-import * as Bluebird from "bluebird";
 import { assert as t } from "chai";
 import * as fs from "fs";
-import * as mkdirpOld from "mkdirp";
 import "mocha";
 import * as path from "path";
 import * as rimraf from "rimraf";
 
-const mkdirp = Bluebird.promisify(mkdirpOld);
-
 describe("writeFiles", () => {
-  const dest = path.resolve(__dirname, "../fixtures/tmp/");
+  const dest = path.resolve(__dirname, "../tmp");
 
   beforeEach(done => {
     rimraf(dest, done);
@@ -24,12 +20,13 @@ describe("writeFiles", () => {
 
   it("should write IFile[] to disk", () => {
     let files: IFile[] = [{
+      base: "",
       content: "Hello World!",
       location: "whatever/hello.txt",
       map: null,
     }];
 
-    return mkdirp(dest).then(() => files)
+    return Promise.resolve(files)
     .then(write(dest))
     .then((res: IFile[]) => {
       const file = res[0];
@@ -41,6 +38,23 @@ describe("writeFiles", () => {
       t.equal(content, "Hello World!");
       return out;
     });
+  });
+
+  it("should keep subfolder structure when writing files", () => {
+    let files: IFile[] = [{
+      base: "/root/whatever",
+      content: "Hello World!",
+      location: "/root/whatever/hello.scss",
+      map: null,
+    }];
+
+    return Promise.resolve(files)
+      .then(write(dest))
+      .then((res: IFile[]) => {
+        res.forEach(file => {
+          t.equal(file.location, dest + "/root/whatever/hello.scss");
+        });
+      });
   });
 
   it.skip("should write files with sourcemaps to disk", () => {

--- a/test/plugins/node-sass/compile.spec.ts
+++ b/test/plugins/node-sass/compile.spec.ts
@@ -7,6 +7,7 @@ import "mocha";
 
 function getFiles(name: string): IFile[] {
   return [{
+    base: __dirname + "/fixtures",
     content: fs.readFileSync(getFixture(name), "utf-8"),
     location: getFixture(name),
     map: null,
@@ -16,6 +17,7 @@ function getFiles(name: string): IFile[] {
 describe("compile (node-sass)", () => {
   it("should work", () => {
     const files: IFile[] = [{
+      base: __dirname + "/fixtures",
       location: getFixture("main.scss"),
       map: null,
     }];
@@ -26,6 +28,7 @@ describe("compile (node-sass)", () => {
 
     return compile(options)(files).then(res => {
       t.deepEqual(res, [{
+        base: __dirname + "/fixtures",
         content: "p {\n  font-size: 2rem; }\n\nbody {\n  color: blue; }\n\nbody"
         + " {\n  background: red; }\n",
         location: getFixture("main.css"),
@@ -43,6 +46,7 @@ describe("compile (node-sass)", () => {
 
     return compile(sassOpts)(files).then(res => {
       t.deepEqual(res, [{
+        base: __dirname + "/fixtures",
         content: "h1{display:flex}\n",
         location: getFixture("postcss.css"),
         map: null,

--- a/test/plugins/node-sass/filterSass.spec.ts
+++ b/test/plugins/node-sass/filterSass.spec.ts
@@ -12,8 +12,11 @@ describe("filterSass", () => {
   });
 
   it("should return only root files", () => {
+    const fixture = getFixture("main.scss");
+
     let files: IFile[] = [{
-      location: null,
+      base: __dirname + "/fixtures",
+      location: fixture,
       map: null,
     }];
 
@@ -21,15 +24,15 @@ describe("filterSass", () => {
       searchPath,
     };
 
-    files[0].location = getFixture("main.scss");
-
     t.deepEqual(filter(options)(files), [{
-      location: files[0].location,
+      base: __dirname + "/fixtures",
+      location: fixture,
       map: null,
     }]);
 
     files[0].location = getFixture("components/_a.scss");
     t.deepEqual(filter(options)(files), [{
+      base: __dirname + "/fixtures",
       location: getFixture("main.scss"),
       map: null,
     }]);
@@ -38,12 +41,15 @@ describe("filterSass", () => {
 
   it("should filter duplicate files", () => {
     const files: IFile[] = [{
+      base: __dirname + "/fixtures",
       location: getFixture("components/_a.scss"),
       map: null,
     }, {
+      base: __dirname + "/fixtures",
       location: getFixture("components/_a.scss"),
       map: null,
     }, {
+      base: __dirname + "/fixtures",
       location: getFixture("_b.scss"),
       map: null,
     }];
@@ -53,9 +59,11 @@ describe("filterSass", () => {
     };
 
     t.deepEqual(filter(options)(files), [{
+      base: __dirname + "/fixtures",
       location: getFixture("main.scss"),
       map: null,
     }, {
+      base: __dirname + "/fixtures",
       location: getFixture("main2.scss"),
       map: null,
     }]);

--- a/test/plugins/node-sass/getRootFiles.spec.ts
+++ b/test/plugins/node-sass/getRootFiles.spec.ts
@@ -7,18 +7,21 @@ import "mocha";
 describe("getRootFiles", () => {
   it("should get root file", () => {
     let file: IFile = {
+      base: __dirname + "/fixtures",
       location: null,
       map: null,
     };
 
     file.location = getFixture("main.scss");
     t.deepEqual(root(fixturePath, file), [{
+      base: __dirname + "/fixtures",
       location: file.location,
       map: null,
     }]);
 
     file.location = getFixture("components/_a.scss");
     t.deepEqual(root(fixturePath, file), [{
+      base: __dirname + "/fixtures",
       location: getFixture("main.scss"),
       map: null,
     }]);
@@ -27,14 +30,17 @@ describe("getRootFiles", () => {
 
   it("should get multiple root files", () => {
     const file: IFile = {
+      base: __dirname + "/fixtures",
       location: getFixture("_b.scss"),
       map: null,
     };
 
     t.deepEqual(root(fixturePath, file), [{
+      base: __dirname + "/fixtures",
       location: getFixture("main.scss"),
       map: null,
     }, {
+      base: __dirname + "/fixtures",
       location: getFixture("main2.scss"),
       map: null,
     }]);
@@ -42,6 +48,7 @@ describe("getRootFiles", () => {
 
   it("should filter partials", () => {
     const file: IFile = {
+      base: __dirname + "/fixtures",
       location: getFixture("components/_no-parents.scss"),
       map: null,
     };

--- a/test/plugins/postcss/compile.spec.ts
+++ b/test/plugins/postcss/compile.spec.ts
@@ -8,6 +8,7 @@ import "mocha";
 
 function getFiles(name: string): IFile[] {
   return [{
+    base: __dirname + "/fixtures",
     content: fs.readFileSync(getFixture(name), "utf-8"),
     location: getFixture(name),
     map: null,
@@ -28,6 +29,7 @@ describe("compile (postcss)", () => {
 
     return compile(postCssOpts)(files).then(res => {
       t.deepEqual(res, [{
+        base: __dirname + "/fixtures",
         content: "h1 {\n  display: -webkit-box;\n  display: -webkit-flex;\n"
         + "  display: -ms-flexbox;\n  display: flex;\n}\n",
         location: getFixture("postcss.css"),
@@ -50,6 +52,7 @@ describe("compile (postcss)", () => {
 
     return compile(postCssOpts)(files).then(res => {
       t.deepEqual(res, [{
+        base: __dirname + "/fixtures",
         content: "h1 {\n  display: -webkit-box;\n  display: -webkit-flex;\n"
         + "  display: -ms-flexbox;\n  display: flex;\n}\n",
         location: getFixture("postcss.css"),
@@ -72,6 +75,7 @@ describe("compile (postcss)", () => {
 
     return compile(postCssOpts)(files).then(res => {
       t.deepEqual(res, [{
+        base: __dirname + "/fixtures",
         content: "h1 {\n  display: flex;\n}\n",
         location: getFixture("postcss.css"),
         map: null,
@@ -88,6 +92,7 @@ describe("compile (postcss)", () => {
 
     return compile(postCssOpts)(files).then(res => {
       t.deepEqual(res, [{
+        base: __dirname + "/fixtures",
         content: ".one {\n  background-color: brown;\n}\n\n.two {\n  "
           + "background-color: brown;\n}\n",
         location: getFixture("cssnext.css"),
@@ -105,6 +110,7 @@ describe("compile (postcss)", () => {
 
     return compile(postCssOpts)(files).then(res => {
       t.deepEqual(res, [{
+        base: __dirname + "/fixtures",
         content: ":root {\n  --main-bg-color: brown;\n}\n\n.one {\n  "
           + "background-color: var(--main-bg-color);\n}\n\n.two {\n  "
           + "background-color: var(--main-bg-color);\n}\n",

--- a/test/utils/fileFromMatch.spec.ts
+++ b/test/utils/fileFromMatch.spec.ts
@@ -4,16 +4,27 @@ import "mocha";
 
 describe("filesFromMatch", () => {
   it("should create an IFile object from a match", () => {
-    t.deepEqual(match(["myfile.scss"]), [{
-      location: "myfile.scss",
+    t.deepEqual(match(["/whatever/myfile.scss"], "/whatever/"), [{
+      base: "",
+      location: "/whatever/myfile.scss",
       map: null,
     }]);
 
-    t.deepEqual(match(["/a/myfile.scss", "/myfile.scss"]), [{
-      location: "/a/myfile.scss",
+    t.deepEqual(match(["/whatever/a/myfile.scss", "/whatever/myfile.scss"], "/whatever/"), [{
+      base: "a",
+      location: "/whatever/a/myfile.scss",
       map: null,
     }, {
-      location: "/myfile.scss",
+      base: "",
+      location: "/whatever/myfile.scss",
+      map: null,
+    }]);
+  });
+
+  it("should create correct relative paths", () => {
+    t.deepEqual(match(["/home/whatever/myfile.scss"], "/home/"), [{
+      base: "whatever",
+      location: "/home/whatever/myfile.scss",
       map: null,
     }]);
   });


### PR DESCRIPTION
This was a requested feature by one team with lots of root sass files. To keep the structure sane, they rely on subfolders. Previously kiki just searched for all files and flat out wrote them into the target directory without any respect for the folder structure.

The PR works by getting the folder structure and the relative file path from the glob path.