### PR TITLE
Add option to force production builds

### DIFF
--- a/bin/kiki
+++ b/bin/kiki
@@ -17,6 +17,9 @@ const yargs = require('yargs')
     requiresArg: true,
     describe: 'Path to config file'
   })
+  .option('production', {
+    describe: 'Force production builds'
+  })
   .option('v', {
     alias: 'version',
     describe: 'Show installed kiki-bundler version'
@@ -58,7 +61,8 @@ if (typeof config !== 'undefined') {
 }
 
 const args = [];
-args.push(config)
+args.push(config);
+args.push(!!yargs.production);
 
 const result = spawn.sync(
   'node',

--- a/src/cli/watch.ts
+++ b/src/cli/watch.ts
@@ -3,6 +3,11 @@ import { build } from "../tasks/build";
 import { watch } from "../tasks/watch";
 
 const configPath = process.argv[2];
+const forceProduction = process.argv[3];
+
+if (forceProduction) {
+  process.env.NODE_ENV = "production";
+}
 
 const config = getConfig(configPath);
 build(config)


### PR DESCRIPTION
One team add work needed production builds while in watch mode. This PR adds a `--production` cli flag, which forces production builds, even in watch mode.